### PR TITLE
Upgrade to Spring Boot 3.5.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.tcu.cs</groupId>
@@ -15,7 +15,7 @@
     <description>hogwarts-artifacts-online</description>
     <properties>
         <java.version>17</java.version>
-        <spring-cloud-azure.version>5.19.0</spring-cloud-azure.version>
+        <spring-cloud-azure.version>5.23.0</spring-cloud-azure.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/edu/tcu/cs/hogwartsartifactsonline/artifact/ArtifactService.java
+++ b/src/main/java/edu/tcu/cs/hogwartsartifactsonline/artifact/ArtifactService.java
@@ -101,7 +101,7 @@ public class ArtifactService {
     }
 
     public Page<Artifact> findByCriteria(Map<String, String> searchCriteria, Pageable pageable) {
-        Specification<Artifact> spec = Specification.where(null);
+        Specification<Artifact> spec = Specification.unrestricted(); // Start with an unrestricted specification, matching all objects.
 
         if (StringUtils.hasLength(searchCriteria.get("id"))) {
             spec = spec.and(ArtifactSpecs.hasId(searchCriteria.get("id")));

--- a/src/main/java/edu/tcu/cs/hogwartsartifactsonline/security/SecurityConfiguration.java
+++ b/src/main/java/edu/tcu/cs/hogwartsartifactsonline/security/SecurityConfiguration.java
@@ -20,10 +20,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -79,7 +76,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.PATCH, this.baseUrl + "/users/**").access(this.userRequestAuthorizationManager) // The authorization rule is defined in the UserRequestAuthorizationManager.
                         .requestMatchers(EndpointRequest.to("health", "info", "prometheus")).permitAll()
                         .requestMatchers(EndpointRequest.toAnyEndpoint().excluding("health", "info", "prometheus")).hasAuthority("ROLE_admin")
-                        .requestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/**")).permitAll() // Explicitly fallback to antMatcher inside requestMatchers.
+                        .requestMatchers("/h2-console/**").permitAll() // Explicitly fallback to antMatcher inside requestMatchers.
                         // Disallow everything else.
                         .anyRequest().authenticated() // Always a good idea to put this as last.
                 )


### PR DESCRIPTION
1. Deprecation of Specification.where(null). where(null) has been deprecated in favor of unrestricted(). For more info, see here:
- [Specification.where(spec) is deprecated without further notice](https://github.com/spring-projects/spring-data-jpa/issues/3893)
- [Backport Specification.unrestricted() to 3.5.x](https://github.com/spring-projects/spring-data-jpa/issues/3942)

See
- ArtifactService.java

2. Which Version of Spring Cloud Azure Should I Use in Spring Boot 3.5.x?
`<spring-cloud-azure.version>5.23.0</spring-cloud-azure.version>`

3. AntPathRequestMatcher has been deprecated for a long time. Updated Spring Security configuration to use the simplified .requestMatchers("/h2-console/**") syntax instead. This change removes deprecation warnings and aligns the configuration with Spring Boot 4 best practices.

See
- SecurityConfiguration.java